### PR TITLE
SO1S-462 내비바 링크 영역이 텍스트로 한정되어 너무 작은 문제 해결

### DIFF
--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -1,10 +1,11 @@
 import { useAtom } from 'jotai';
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import currentPage from '../atoms/current-page';
 import routes from '../constants/routes';
 
 const NavBar: React.FC = () => {
     const [, setPage] = useAtom(currentPage);
+    const navigate = useNavigate();
     return (
         <nav className="w-[15vw] h-[95vh] bg-white divide-y divide-[#e5e7eb]">
             {routes
@@ -16,19 +17,18 @@ const NavBar: React.FC = () => {
                         // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
                         <div
                             key={e.name}
-                            className="h-20 flex flex-grow"
-                            onClick={() => setPage(e)}
+                            className="h-20 flex flex-grow cursor-pointer"
+                            onClick={() => {
+                                setPage(e);
+                                navigate(e.uri);
+                            }}
                         >
-                            <Link
-                                replace
-                                to={e.uri}
-                                className="flex flex-row my-auto space-x-3 ml-2"
-                            >
+                            <div className="flex flex-row my-auto space-x-3 ml-2">
                                 <div className="">{e.icon}</div>
                                 <div className="font-sans my-auto">
                                     {e.name}
                                 </div>
-                            </Link>
+                            </div>
                         </div>
                     );
                 })


### PR DESCRIPTION
# 내비바 링크 영역이 텍스트로 한정되어 너무 작은 문제 해결


## Tasks

- [x] Link 컴포넌트를 div로 대체
- [x] Tailwind CSS `cursor-pointer` 프로퍼티 적용
- [x] onClick 로직 추가
- [x] Redirect가 아닌 Navigate 조치



## Discussion

## Jira

- SO1S-462