### PR TITLE
SO1S-438 Axios Interceptor를 통한 액세스 토큰 만료 핸들링

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -8,7 +8,7 @@ const axiosInstance = axios.create({ baseURL });
 export const axiosInstanceRef = new Proxy({ current: axiosInstance }, {});
 
 const useAuth = () => {
-    const [accessToken] = useAtom(accessTokenWithPersistence);
+    const [accessToken, setAccessToken] = useAtom(accessTokenWithPersistence);
 
     useEffect(() => {
         axiosInstanceRef.current = axios.create({
@@ -18,7 +18,18 @@ const useAuth = () => {
                 Authorization: `Bearer ${accessToken}`,
             },
         });
-    }, [accessToken]);
+
+        axiosInstanceRef.current.interceptors.response.use(
+            (response) => response,
+            (error) => {
+                if (error.response.status === 401) {
+                    setAccessToken('');
+                }
+
+                return Promise.reject(error);
+            }
+        );
+    }, [accessToken, setAccessToken]);
 };
 
 export default useAuth;


### PR DESCRIPTION
# Axios Interceptor를 통한 액세스 토큰 만료 핸들링


## Tasks

- [x] useEffect를 통한 401 인터셉터 작성
- [x] 토큰 만료시 flush 조치를 통한 로그인 페이지 리다이렉션 처리
- [x] Backend `jwt.token-validity-in-seconds` 파라미터 수정을 통한 동작 확인


## Discussion

## Jira

- SO1S-438