### PR TITLE
SO1S-532 모델 메타데이터 id undefined 케이스 헨들링

### DIFF
--- a/src/api/models/index.ts
+++ b/src/api/models/index.ts
@@ -19,6 +19,7 @@ export const getModels = async () => {
 
 export const getModelMetadataById = async (id?: number) => {
     if (id === undefined) {
+        // eslint-disable-next-line no-promise-executor-return
         await new Promise((res) => setTimeout(res, 100));
         return [];
     }

--- a/src/api/models/index.ts
+++ b/src/api/models/index.ts
@@ -17,7 +17,12 @@ export const getModels = async () => {
     return response.data as IModelFindResponse[];
 };
 
-export const getModelMetadataById = async (id: number) => {
+export const getModelMetadataById = async (id?: number) => {
+    if (id === undefined) {
+        await new Promise((res) => setTimeout(res, 100));
+        return [];
+    }
+
     const { current: axiosInstance } = axiosInstanceRef;
     const response = await axiosInstance.get(`${baseURL}/api/v1/models/${id}`);
 

--- a/src/hooks/useData.ts
+++ b/src/hooks/useData.ts
@@ -91,5 +91,7 @@ export const useData = <
         }
     }, [needRefesh, getData, setNeedRefresh]);
 
+    useEffect(() => () => setData([]), []);
+
     return [data, refresh] as const;
 };

--- a/src/pages/deployments/create-update-base.tsx
+++ b/src/pages/deployments/create-update-base.tsx
@@ -35,10 +35,7 @@ const CreateUpdateDeploymentBase: React.FC<ICreateUpdateBaseParams> = ({
     type,
 }: ICreateUpdateBaseParams) => {
     const [resources] = useResourcesData();
-    const [resource, setResource] = useState<IResourceFind | null>(
-        resources[0] ?? null
-    );
-
+    const [resource, setResource] = useState<IResourceFind | null>(null);
     const [models] = useModelsData();
     const [modelMetadata, modelMetadataRefresh] = useModelMetadata();
     const [deployments] = useDeploymentsData();
@@ -188,15 +185,15 @@ const CreateUpdateDeploymentBase: React.FC<ICreateUpdateBaseParams> = ({
     };
 
     useEffect(() => {
-        if (type === 'update' && deployment) {
+        if (deployment) {
             const modelId = models.find(
                 (model) => model.name === deployment.modelName
             )?.id;
-            if (modelId) {
+            if (modelId !== undefined) {
                 modelMetadataRefresh(modelId);
             }
         }
-    }, [type, deployment]);
+    }, [deployment]);
 
     if (type === 'update' && !deployment) {
         setSnackbarDatum({


### PR DESCRIPTION
# 모델 메타데이터 id undefined 케이스 헨들링


## Tasks

- [x] id undefined일 경우 무한 스레드 블러킹을 막기 위해 Promise 래핑 후 빈 Array 반환
- [x] useData 내부에서 Cleanup 핸들러를 통해 잘못 동작될 가능성이 높은 Atom 데이터 캐시 제거


## Discussion


## Jira

- SO1S-532