### PR TITLE
SO1S-483 ABN 테스트 페이지 개발 및 API 연동

### DIFF
--- a/src/api/tests/ab/index.ts
+++ b/src/api/tests/ab/index.ts
@@ -1,11 +1,11 @@
-import { baseURL } from '../../constants';
-import { axiosInstanceRef } from '../../hooks/useAuth';
+import { baseURL } from '../../../constants';
+import { axiosInstanceRef } from '../../../hooks/useAuth';
 import {
     IABTestCreateRequest,
     IABTestCreateResponse,
     IABTestDeleteResponse,
     IABTestReadResponse,
-} from '../../interfaces/pages/tests';
+} from '../../../interfaces/pages/tests/ab';
 
 export const getABTests = async () => {
     const { current: axiosInstance } = axiosInstanceRef;

--- a/src/api/tests/abn/index.ts
+++ b/src/api/tests/abn/index.ts
@@ -1,0 +1,39 @@
+import { baseURL } from '../../../constants';
+import { axiosInstanceRef } from '../../../hooks/useAuth';
+import {
+    IABNTestCreateRequest,
+    IABNTestCreateResponse,
+    IABNTestDeleteResponse,
+    IABNTestReadResponse,
+} from '../../../interfaces/pages/tests/abn';
+
+export const getABNTests = async () => {
+    const { current: axiosInstance } = axiosInstanceRef;
+    const response = await axiosInstance.get(`${baseURL}/api/v2/tests/ab`);
+
+    return response.data as IABNTestReadResponse[];
+};
+
+export const createOrUpdateABNTest = async (
+    payload: IABNTestCreateRequest,
+    mode: 'post' | 'put' = 'post'
+) => {
+    const { current: axiosInstance } = axiosInstanceRef;
+    const response = await axiosInstance[mode](
+        `${baseURL}/api/v2/tests/ab`,
+        payload
+    );
+
+    return response.data as IABNTestCreateResponse;
+};
+
+export const deleteABNTest = async (id: number) => {
+    const { current: axiosInstance } = axiosInstanceRef;
+    const response = await axiosInstance.delete(
+        `${baseURL}/api/v2/tests/ab/${id}`
+    );
+
+    return response.data as IABNTestDeleteResponse;
+};
+
+export default getABNTests;

--- a/src/atoms/tests.ts
+++ b/src/atoms/tests.ts
@@ -1,4 +1,6 @@
 import { atom } from 'jotai';
-import { IABTestReadResponse } from '../interfaces/pages/tests';
+import { IABTestReadResponse } from '../interfaces/pages/tests/ab';
+import { IABNTestReadResponse } from '../interfaces/pages/tests/abn';
 
 export const abTestsAtom = atom<IABTestReadResponse[]>([]);
+export const abnTestsAtom = atom<IABNTestReadResponse[]>([]);

--- a/src/constants/routes.tsx
+++ b/src/constants/routes.tsx
@@ -33,6 +33,10 @@ import { Nodes } from '../pages/nodes';
 import { NodeDetail } from '../pages/nodes/detail';
 import { Tracing } from '../pages/tracing';
 import { Logging } from '../pages/logging';
+import ABNTests from '../pages/tests/abn';
+import { ABNTestDetail } from '../pages/tests/abn/detail';
+import { CreateABNTest } from '../pages/tests/abn/create';
+import { UpdateABNTest } from '../pages/tests/abn/update';
 
 const routes: IRouterDatum[] = [
     {
@@ -172,6 +176,34 @@ const routes: IRouterDatum[] = [
         name: 'AB Test Update',
         hidden: true,
         page: UpdateABTest,
+        for: ['Owner', 'Admin', 'User'],
+    },
+    {
+        uri: '/tests/abn',
+        name: 'ABN Tests',
+        icon: <SpeedIcon fontSize="large" />,
+        page: ABNTests,
+        for: ['Owner', 'Admin', 'User'],
+    },
+    {
+        uri: '/tests/abn/:id',
+        name: 'ABN Test Detail',
+        hidden: true,
+        page: ABNTestDetail,
+        for: ['Owner', 'Admin', 'User'],
+    },
+    {
+        uri: '/tests/abn/create',
+        name: 'ABN Test Create',
+        hidden: true,
+        page: CreateABNTest,
+        for: ['Owner', 'Admin', 'User'],
+    },
+    {
+        uri: '/tests/abn/update/:abnTestName',
+        name: 'ABN Test Update',
+        hidden: true,
+        page: UpdateABNTest,
         for: ['Owner', 'Admin', 'User'],
     },
     {

--- a/src/constants/routes.tsx
+++ b/src/constants/routes.tsx
@@ -200,7 +200,7 @@ const routes: IRouterDatum[] = [
         for: ['Owner', 'Admin', 'User'],
     },
     {
-        uri: '/tests/abn/update/:abnTestName',
+        uri: '/tests/abn/update/:id',
         name: 'ABN Test Update',
         hidden: true,
         page: UpdateABNTest,

--- a/src/hooks/data/useABNTestsData.ts
+++ b/src/hooks/data/useABNTestsData.ts
@@ -1,0 +1,6 @@
+import getABNTests from '../../api/tests/abn';
+import { abnTestsAtom } from '../../atoms/tests';
+import { useData } from '../useData';
+
+export const useABNTestsData = () =>
+    useData(abnTestsAtom, getABNTests, { useRawType: true });

--- a/src/hooks/data/useABTestsData.ts
+++ b/src/hooks/data/useABTestsData.ts
@@ -1,4 +1,4 @@
-import getABTests from '../../api/tests';
+import getABTests from '../../api/tests/ab';
 import { abTestsAtom } from '../../atoms/tests';
 import { useData } from '../useData';
 

--- a/src/hooks/useData.ts
+++ b/src/hooks/useData.ts
@@ -76,7 +76,13 @@ export const useData = <
             });
             setData(data as IDatum[]);
         } catch (err) {
-            if ((err as AxiosError).response?.status === 500) {
+            const error = err as AxiosError;
+
+            // handle err_connection_refused
+            if (!error.response) {
+                return;
+            }
+            if (error.response?.status === 500) {
                 return;
             }
 

--- a/src/interfaces/pages/tests/ab/index.ts
+++ b/src/interfaces/pages/tests/ab/index.ts
@@ -1,5 +1,5 @@
-import { IBaseResponse } from '../..';
-import { IDeploymentDatum } from '../deployments';
+import { IBaseResponse } from '../../..';
+import { IDeploymentDatum } from '../../deployments';
 
 export interface IABTestBaseResponse {
     name: string;

--- a/src/interfaces/pages/tests/abn/index.ts
+++ b/src/interfaces/pages/tests/abn/index.ts
@@ -1,0 +1,39 @@
+import { IBaseResponse } from '../../..';
+import { IDeploymentDatum } from '../../deployments';
+
+export interface IABNTestElement {
+    deploymentId: number;
+    weight: number;
+}
+
+export interface IABNTestElementJoined {
+    deployment: IDeploymentDatum;
+    weight: number;
+}
+
+export interface IABNTestBaseResponse {
+    name: string;
+    domain: string;
+}
+
+export type IABNTestReadResponse = {
+    id: number;
+    elements: IABNTestElement[];
+} & IABNTestBaseResponse;
+
+export type IABNTestCreateRequest = {
+    elements: IABNTestElement[];
+} & IABNTestBaseResponse;
+
+export type IABNTestDeleteResponse = IBaseResponse;
+export type IABNTestCreateResponse = {
+    data: IABNTestReadResponse;
+} & IBaseResponse;
+
+export type IABNTestView = {
+    id: number;
+} & IABNTestBaseResponse;
+
+export type IABNTestJoined = {
+    elements: IABNTestElementJoined[];
+} & IABNTestView;

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -4,11 +4,11 @@ import SpeedIcon from '@mui/icons-material/Speed';
 import { useEffect, useState, useMemo } from 'react';
 import getDeployments from '../api/deployments';
 import getModels from '../api/models';
-import getABTests from '../api/tests';
+import getABTests from '../api/tests/ab';
 import SummaryCard from '../components/summary-card';
 import { IDeploymentFindResponse } from '../interfaces/pages/deployments';
 import { IModelFindResponse } from '../interfaces/pages/models';
-import { IABTestReadResponse } from '../interfaces/pages/tests';
+import { IABTestReadResponse } from '../interfaces/pages/tests/ab';
 import ISummaries from '../interfaces/pages/home';
 
 const Home: React.FC = () => {

--- a/src/pages/tests/ab/create-update-base.tsx
+++ b/src/pages/tests/ab/create-update-base.tsx
@@ -9,7 +9,7 @@ import { pipe } from 'fp-ts/lib/function';
 import { useAtom } from 'jotai';
 import { useRef } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { createOrUpdateABTest } from '../../../api/tests';
+import { createOrUpdateABTest } from '../../../api/tests/ab';
 import { snackbarAtom } from '../../../atoms/snackbar';
 import ActionCard from '../../../components/action-card';
 import { useABTestsData } from '../../../hooks/data/useABTestsData';
@@ -121,8 +121,9 @@ export const CreateUpdateABTestBase: React.FC<ICreateUpdateBaseParams> = ({
             <div className="flex flex-col space-y-10 my-10 mx-auto">
                 <TextField
                     label={`AB Test Name${
-                        type === 'update' &&
-                        `: ${abTest?.name ?? 'Not Found'} (Disabled)`
+                        type === 'update'
+                            ? `: ${abTest?.name ?? 'Not Found'} (Disabled)`
+                            : ''
                     }`}
                     disabled={type === 'update'}
                     placeholder="AB Test"

--- a/src/pages/tests/ab/detail.tsx
+++ b/src/pages/tests/ab/detail.tsx
@@ -1,13 +1,13 @@
 import { useAtom } from 'jotai';
 import { useNavigate, useParams } from 'react-router-dom';
-import { deleteABTest } from '../../../api/tests';
+import { deleteABTest } from '../../../api/tests/ab';
 import { snackbarAtom } from '../../../atoms/snackbar';
 import { DetailCard } from '../../../components/detail/card';
 import OverViewTab from '../../../components/detail/overview-tab';
 import { useABTestsData } from '../../../hooks/data/useABTestsData';
 import { useDelete } from '../../../hooks/useDelete';
 import { useDeploymentsData } from '../../../hooks/data/useDeploymentsData';
-import { IABTestJoined } from '../../../interfaces/pages/tests';
+import { IABTestJoined } from '../../../interfaces/pages/tests/ab';
 import { joinABTest } from '../../../utils/pages/tests/ab';
 
 export const ABTestDetail = () => {

--- a/src/pages/tests/ab/index.tsx
+++ b/src/pages/tests/ab/index.tsx
@@ -1,9 +1,9 @@
-import { deleteABTest } from '../../../api/tests';
+import { deleteABTest } from '../../../api/tests/ab';
 import ListTable from '../../../components/table';
 import { useABTestsData } from '../../../hooks/data/useABTestsData';
 import { useDelete } from '../../../hooks/useDelete';
 import { useDeploymentsData } from '../../../hooks/data/useDeploymentsData';
-import { IABTestView } from '../../../interfaces/pages/tests';
+import { IABTestView } from '../../../interfaces/pages/tests/ab';
 import { convertABTestToView } from '../../../utils/pages/tests/ab';
 
 const ABTests: React.FC = () => {

--- a/src/pages/tests/abn/create-update-base.tsx
+++ b/src/pages/tests/abn/create-update-base.tsx
@@ -1,0 +1,248 @@
+import {
+    Button,
+    FormControl,
+    InputLabel,
+    MenuItem,
+    Select,
+    SelectChangeEvent,
+    TextField,
+} from '@mui/material';
+import { pipe } from 'fp-ts/lib/function';
+import { useAtom } from 'jotai';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { createOrUpdateABNTest } from '../../../api/tests/abn';
+import { snackbarAtom } from '../../../atoms/snackbar';
+import ActionCard from '../../../components/action-card';
+import { useABNTestsData } from '../../../hooks/data/useABNTestsData';
+import { useDeploymentsData } from '../../../hooks/data/useDeploymentsData';
+import { IABNTestElement } from '../../../interfaces/pages/tests/abn';
+import { ICreateUpdateBaseParams } from '../../../interfaces';
+
+export const CreateUpdateABNTestBase: React.FC<ICreateUpdateBaseParams> = ({
+    type,
+}: ICreateUpdateBaseParams) => {
+    const [abnTests] = useABNTestsData();
+    const [deployments] = useDeploymentsData();
+    const [elementsSize, setElementsSize] = useState(1);
+    const elements = useRef<IABNTestElement[]>([]);
+
+    const navigate = useNavigate();
+
+    const [, setSnackbarDatum] = useAtom(snackbarAtom);
+
+    const setError = (message: string) => {
+        setSnackbarDatum({
+            severity: 'error',
+            message,
+        });
+    };
+
+    const nameRef = useRef<HTMLInputElement>(null);
+    const domainRef = useRef<HTMLInputElement>(null);
+
+    const { abnTestName } = useParams();
+    const abnTest = abnTests.find((test) => test.name === abnTestName);
+
+    useEffect(() => {
+        if (type === 'update' && abnTest) {
+            elements.current = [...abnTest.elements];
+            setElementsSize(abnTest.elements.length);
+        }
+    }, [abnTest, type]);
+
+    useEffect(() => {
+        while (elementsSize > elements.current.length) {
+            elements.current.push({
+                deploymentId: deployments[0]?.id ?? 0,
+                weight: 0,
+            });
+        }
+        while (elementsSize < elements.current.length) {
+            elements.current.pop();
+        }
+    }, [elementsSize]);
+
+    if (type === 'update' && !abnTestName) {
+        setError(`AB Test Name이 주어지지 않았습니다.`);
+        navigate('/tests/abn', { replace: true });
+        return <></>;
+    }
+
+    if (type === 'update' && !abnTest) {
+        setError(`Name과 일치하는 AB Test 객체를 찾지 못했습니다.`);
+        navigate('/tests/abn', { replace: true });
+        return <></>;
+    }
+
+    const submit = async () => {
+        const items = {
+            name: nameRef,
+            domain: domainRef,
+        };
+
+        const itemsWithValues = pipe(
+            items,
+            Object.entries,
+            (arr) => arr.map(([k, v]) => [k, v.current?.value]),
+            Object.fromEntries
+        ) as { [k in keyof typeof items]: string | number };
+
+        if (type === 'update') {
+            itemsWithValues.name = abnTest?.name ?? '';
+        }
+
+        const isCorrect = pipe(
+            itemsWithValues,
+            Object.entries,
+
+            (arr) =>
+                arr.every(([name, value]) => {
+                    if (value !== 0 && !value) {
+                        setError(`${name}이(가) 주어지지 않았습니다.`);
+                        return false;
+                    }
+                    return true;
+                })
+        );
+
+        if (!isCorrect) {
+            return;
+        }
+
+        if (elementsSize < 1) {
+            setError(`하나 이상의 인퍼런스 서버가 정의되어야 합니다.`);
+            return;
+        }
+
+        const mode = type === 'create' ? 'post' : 'put';
+
+        const { name, domain } = itemsWithValues;
+
+        const response = await createOrUpdateABNTest(
+            {
+                name: name as string,
+                domain: domain as string,
+                elements: elements.current,
+            },
+            mode
+        );
+
+        setSnackbarDatum({
+            severity: response.success ? 'success' : 'error',
+            message: JSON.stringify(response.data, null, 4),
+        });
+
+        navigate('/tests/abn');
+    };
+
+    const elementsForm = useMemo(() => {
+        const result = [];
+
+        for (let idx = 0; idx < elementsSize; idx++) {
+            const p1 = idx + 1;
+
+            const handleDeploymentChange = (
+                event: SelectChangeEvent<number>
+            ) => {
+                const {
+                    target: { value },
+                } = event;
+
+                elements.current[idx].deploymentId = +value;
+            };
+
+            const handleWeightChange = (
+                event: React.ChangeEvent<HTMLInputElement>
+            ) => {
+                const {
+                    target: { value },
+                } = event;
+
+                elements.current[idx].weight = +value;
+            };
+
+            result.push(
+                <div className="my-10">
+                    <FormControl key={idx} fullWidth>
+                        <InputLabel id={`deployment-${idx}`}>
+                            Deployment {p1}
+                        </InputLabel>
+                        <div className="space-y-10 flex flex-col">
+                            <Select
+                                label="Deployment"
+                                onChange={handleDeploymentChange}
+                            >
+                                {deployments.map((dep) => (
+                                    <MenuItem key={dep.id} value={dep.id}>
+                                        {dep.deploymentName}
+                                    </MenuItem>
+                                ))}
+                            </Select>
+                            <TextField
+                                label={`Deployment ${p1} Weight`}
+                                type="number"
+                                defaultValue={0}
+                                inputProps={{ min: 0 }}
+                                onChange={handleWeightChange}
+                            />
+                        </div>
+                    </FormControl>
+                </div>
+            );
+        }
+
+        return result;
+    }, [elementsSize]);
+
+    return (
+        <ActionCard
+            title={`${type === 'create' ? 'Create New' : 'Update'} ABN Test`}
+            mode={type === 'create' ? 'CREATE' : 'UPDATE'}
+            onClick={submit}
+        >
+            <div className="flex flex-col space-y-10 my-10 mx-auto">
+                <TextField
+                    label={`ABN Test Name${
+                        type === 'update'
+                            ? `: ${abnTest?.name ?? 'Not Found'} (Disabled)`
+                            : ''
+                    }`}
+                    disabled={type === 'update'}
+                    placeholder="ABN Test"
+                    inputRef={nameRef}
+                />
+                <TextField
+                    label="Domain"
+                    defaultValue={abnTest?.domain}
+                    placeholder="so1s.io"
+                    inputRef={domainRef}
+                />
+            </div>
+            {elementsForm}
+            <div className="flex flex-row w-full">
+                <div className="ml-auto mr-5">
+                    <Button
+                        color="primary"
+                        variant="contained"
+                        onClick={() => setElementsSize(elementsSize + 1)}
+                    >
+                        +
+                    </Button>
+                </div>
+
+                <div className="mr-auto ml-5">
+                    {elementsSize > 1 && (
+                        <Button
+                            color="error"
+                            variant="contained"
+                            onClick={() => setElementsSize(elementsSize - 1)}
+                        >
+                            -
+                        </Button>
+                    )}
+                </div>
+            </div>
+        </ActionCard>
+    );
+};

--- a/src/pages/tests/abn/create-update-base.tsx
+++ b/src/pages/tests/abn/create-update-base.tsx
@@ -24,7 +24,7 @@ export const CreateUpdateABNTestBase: React.FC<ICreateUpdateBaseParams> = ({
 }: ICreateUpdateBaseParams) => {
     const [abnTests] = useABNTestsData();
     const [deployments] = useDeploymentsData();
-    const [elementsSize, setElementsSize] = useState(0);
+    const [elementsSize, setElementsSize] = useState(1);
     const elements = useRef<IABNTestElement[]>([]);
 
     const navigate = useNavigate();
@@ -41,8 +41,8 @@ export const CreateUpdateABNTestBase: React.FC<ICreateUpdateBaseParams> = ({
     const nameRef = useRef<HTMLInputElement>(null);
     const domainRef = useRef<HTMLInputElement>(null);
 
-    const { abnTestName } = useParams();
-    const abnTest = abnTests.find((test) => test.name === abnTestName);
+    const { id } = useParams();
+    const abnTest = abnTests.find((test) => test.id === +id);
 
     useEffect(() => {
         if (type === 'update' && abnTest) {
@@ -63,14 +63,8 @@ export const CreateUpdateABNTestBase: React.FC<ICreateUpdateBaseParams> = ({
         }
     }, [elementsSize]);
 
-    if (type === 'update' && !abnTestName) {
-        setError(`AB Test Name이 주어지지 않았습니다.`);
-        navigate('/tests/abn', { replace: true });
-        return <></>;
-    }
-
-    if (type === 'update' && !abnTest) {
-        setError(`Name과 일치하는 AB Test 객체를 찾지 못했습니다.`);
+    if (type === 'update' && id == null) {
+        setError(`AB Test ID가 주어지지 않았습니다.`);
         navigate('/tests/abn', { replace: true });
         return <></>;
     }
@@ -193,7 +187,7 @@ export const CreateUpdateABNTestBase: React.FC<ICreateUpdateBaseParams> = ({
         }
 
         return result;
-    }, [elementsSize]);
+    }, [elementsSize, deployments]);
 
     return (
         <ActionCard

--- a/src/pages/tests/abn/create-update-base.tsx
+++ b/src/pages/tests/abn/create-update-base.tsx
@@ -24,7 +24,7 @@ export const CreateUpdateABNTestBase: React.FC<ICreateUpdateBaseParams> = ({
 }: ICreateUpdateBaseParams) => {
     const [abnTests] = useABNTestsData();
     const [deployments] = useDeploymentsData();
-    const [elementsSize, setElementsSize] = useState(1);
+    const [elementsSize, setElementsSize] = useState(0);
     const elements = useRef<IABNTestElement[]>([]);
 
     const navigate = useNavigate();

--- a/src/pages/tests/abn/create-update-base.tsx
+++ b/src/pages/tests/abn/create-update-base.tsx
@@ -130,64 +130,62 @@ export const CreateUpdateABNTestBase: React.FC<ICreateUpdateBaseParams> = ({
         navigate('/tests/abn');
     };
 
-    const elementsForm = useMemo(() => {
-        const result = [];
+    const elementsForm = useMemo(
+        () =>
+            new Array(elementsSize).fill(null).map((_, idx) => {
+                const p1 = idx + 1;
 
-        for (let idx = 0; idx < elementsSize; idx++) {
-            const p1 = idx + 1;
+                const handleDeploymentChange = (
+                    event: SelectChangeEvent<number>
+                ) => {
+                    const {
+                        target: { value },
+                    } = event;
 
-            const handleDeploymentChange = (
-                event: SelectChangeEvent<number>
-            ) => {
-                const {
-                    target: { value },
-                } = event;
+                    elements.current[idx].deploymentId = +value;
+                };
 
-                elements.current[idx].deploymentId = +value;
-            };
+                const handleWeightChange = (
+                    event: React.ChangeEvent<HTMLInputElement>
+                ) => {
+                    const {
+                        target: { value },
+                    } = event;
 
-            const handleWeightChange = (
-                event: React.ChangeEvent<HTMLInputElement>
-            ) => {
-                const {
-                    target: { value },
-                } = event;
+                    elements.current[idx].weight = +value;
+                };
 
-                elements.current[idx].weight = +value;
-            };
-
-            result.push(
-                <div className="my-10">
-                    <FormControl key={idx} fullWidth>
-                        <InputLabel id={`deployment-${idx}`}>
-                            Deployment {p1}
-                        </InputLabel>
-                        <div className="space-y-10 flex flex-col">
-                            <Select
-                                label="Deployment"
-                                onChange={handleDeploymentChange}
-                            >
-                                {deployments.map((dep) => (
-                                    <MenuItem key={dep.id} value={dep.id}>
-                                        {dep.deploymentName}
-                                    </MenuItem>
-                                ))}
-                            </Select>
-                            <TextField
-                                label={`Deployment ${p1} Weight`}
-                                type="number"
-                                defaultValue={0}
-                                inputProps={{ min: 0 }}
-                                onChange={handleWeightChange}
-                            />
-                        </div>
-                    </FormControl>
-                </div>
-            );
-        }
-
-        return result;
-    }, [elementsSize, deployments]);
+                return (
+                    <div key={idx} className="my-10">
+                        <FormControl fullWidth>
+                            <InputLabel id={`deployment-${idx}`}>
+                                Deployment {p1}
+                            </InputLabel>
+                            <div className="space-y-10 flex flex-col">
+                                <Select
+                                    label="Deployment"
+                                    onChange={handleDeploymentChange}
+                                >
+                                    {deployments.map((dep) => (
+                                        <MenuItem key={dep.id} value={dep.id}>
+                                            {dep.deploymentName}
+                                        </MenuItem>
+                                    ))}
+                                </Select>
+                                <TextField
+                                    label={`Deployment ${p1} Weight`}
+                                    type="number"
+                                    defaultValue={0}
+                                    inputProps={{ min: 0 }}
+                                    onChange={handleWeightChange}
+                                />
+                            </div>
+                        </FormControl>
+                    </div>
+                );
+            }),
+        [elementsSize, deployments]
+    );
 
     return (
         <ActionCard

--- a/src/pages/tests/abn/create.tsx
+++ b/src/pages/tests/abn/create.tsx
@@ -1,0 +1,5 @@
+import { CreateUpdateABNTestBase } from './create-update-base';
+
+export const CreateABNTest = () => {
+    return <CreateUpdateABNTestBase type="create" />;
+};

--- a/src/pages/tests/abn/detail.tsx
+++ b/src/pages/tests/abn/detail.tsx
@@ -50,7 +50,8 @@ export const ABNTestDetail = () => {
         return <></>;
     }
 
-    const abnTestJoined = joinABNTest(abnTest, deployments);
+    const abnTestJoined =
+        abnTest !== undefined ? joinABNTest(abnTest, deployments) : undefined;
 
     const headElements = ['ID', 'Name', 'Domain'].concat(
         abnTest?.elements

--- a/src/pages/tests/abn/detail.tsx
+++ b/src/pages/tests/abn/detail.tsx
@@ -1,0 +1,110 @@
+import { useAtom } from 'jotai';
+import { useNavigate, useParams } from 'react-router-dom';
+import { snackbarAtom } from '../../../atoms/snackbar';
+import { DetailCard } from '../../../components/detail/card';
+import OverViewTab from '../../../components/detail/overview-tab';
+import { useDelete } from '../../../hooks/useDelete';
+import { useDeploymentsData } from '../../../hooks/data/useDeploymentsData';
+import { joinABNTest } from '../../../utils/pages/tests/abn';
+import { useABNTestsData } from '../../../hooks/data/useABNTestsData';
+import { deleteABNTest } from '../../../api/tests/abn';
+
+export const ABNTestDetail = () => {
+    const [abnTests] = useABNTestsData();
+    const [deployments] = useDeploymentsData();
+
+    const navigate = useNavigate();
+    const [, setSnackbarDatum] = useAtom(snackbarAtom);
+
+    const params = useParams();
+
+    const performDelete = useDelete(deleteABNTest);
+
+    const deleteAction = async (id: number) => {
+        const success = await performDelete(id);
+
+        navigate(`/tests/abn`, { replace: true });
+
+        return success;
+    };
+
+    const { id } = params;
+
+    if (!id) {
+        setSnackbarDatum({
+            severity: 'error',
+            message: 'name이 주어지지 않았습니다.',
+        });
+        navigate('/tests/abn', { replace: true });
+        return <></>;
+    }
+
+    const abnTest = abnTests.find((e) => e.id === +id);
+
+    if (abnTests.length && !abnTest) {
+        setSnackbarDatum({
+            severity: 'error',
+            message: 'abnTestName과 일치하는 AB Test 객체를 찾지 못했습니다.',
+        });
+        navigate('/tests/abn', { replace: true });
+        return <></>;
+    }
+
+    const abnTestJoined = joinABNTest(abnTest, deployments);
+
+    const headElements = ['ID', 'Name', 'Domain'].concat(
+        abnTest?.elements
+            .map((e, idx) => {
+                const p1 = idx + 1;
+                return [
+                    `Deployment ${p1} Name`,
+                    `Deployment ${p1} Weight`,
+                    `Deployment ${p1} Status`,
+                    `Deployment ${p1} Model Name`,
+                    `Deployment ${p1} Model Version`,
+                    `Deployment ${p1} Deployment Strategy`,
+                ];
+            })
+            .reduce((a, b) => a.concat(b), []) ?? []
+    );
+
+    const deploymentDivs =
+        abnTestJoined?.elements
+            ?.map(({ deployment, weight }) => (
+                <>
+                    <div>{deployment?.deploymentName}</div>
+                    <div>{weight}</div>
+                    <div>{deployment?.status}</div>
+                    <div>{deployment?.modelName}</div>
+                    <div>{deployment?.modelVersion}</div>
+                    <div>{deployment?.strategy}</div>
+                </>
+            ))
+            .map((e) => e.props.children)
+            .reduce((a, b) => a.concat(b), []) ?? [];
+
+    return (
+        <div>
+            <DetailCard
+                title="ABN Test Details"
+                tabs={['OverView']}
+                deleteHandler={() => {
+                    if (abnTest?.id === undefined) {
+                        return;
+                    }
+                    deleteAction(abnTest.id);
+                }}
+            >
+                <OverViewTab headEl={headElements}>
+                    {/* https://stackoverflow.com/a/61475211/11853111 */}
+                    {[
+                        <div key="id">{abnTestJoined?.id}</div>,
+                        <div key="name">{abnTestJoined?.name}</div>,
+                        <div key="domain">{abnTestJoined?.domain}</div>,
+                    ].concat(deploymentDivs)}
+                </OverViewTab>
+                <></>
+            </DetailCard>
+        </div>
+    );
+};

--- a/src/pages/tests/abn/index.tsx
+++ b/src/pages/tests/abn/index.tsx
@@ -1,0 +1,43 @@
+import { deleteABNTest } from '../../../api/tests/abn';
+import ListTable from '../../../components/table';
+import { useABNTestsData } from '../../../hooks/data/useABNTestsData';
+import { useDelete } from '../../../hooks/useDelete';
+import { IABNTestView } from '../../../interfaces/pages/tests/abn';
+import { convertABNTestToView } from '../../../utils/pages/tests/abn';
+
+const ABNTests: React.FC = () => {
+    const [abnTests, refreshData] = useABNTestsData();
+
+    const abnTestsView: IABNTestView[] = abnTests.map((abnTest) =>
+        convertABNTestToView(abnTest)
+    );
+
+    const performDelete = useDelete(deleteABNTest);
+
+    const deleteAction = async (id: number) => {
+        const success = await performDelete(id);
+
+        refreshData();
+
+        return success;
+    };
+
+    console.log({ abnTests });
+
+    return (
+        <div>
+            <ListTable
+                title="ABN Tests"
+                items={abnTestsView}
+                itemKey="id"
+                hasDetail
+                creatable
+                editable
+                deletable
+                deleteAction={deleteAction}
+            />
+        </div>
+    );
+};
+
+export default ABNTests;

--- a/src/pages/tests/abn/update.tsx
+++ b/src/pages/tests/abn/update.tsx
@@ -1,0 +1,5 @@
+import { CreateUpdateABNTestBase } from './create-update-base';
+
+export const UpdateABNTest = () => {
+    return <CreateUpdateABNTestBase type="update" />;
+};

--- a/src/utils/pages/tests/ab/index.ts
+++ b/src/utils/pages/tests/ab/index.ts
@@ -3,7 +3,7 @@ import {
     IABTestJoined,
     IABTestReadResponse,
     IABTestView,
-} from '../../../../interfaces/pages/tests';
+} from '../../../../interfaces/pages/tests/ab';
 
 export const joinABTest = (
     abTest: IABTestReadResponse,

--- a/src/utils/pages/tests/abn/index.ts
+++ b/src/utils/pages/tests/abn/index.ts
@@ -1,0 +1,31 @@
+import { IDeploymentDatum } from '../../../../interfaces/pages/deployments';
+import {
+    IABNTestJoined,
+    IABNTestReadResponse,
+    IABNTestView,
+} from '../../../../interfaces/pages/tests/abn';
+
+export const convertABNTestToView = (
+    abnTest: IABNTestReadResponse
+): IABNTestView => {
+    return {
+        id: abnTest.id,
+        name: abnTest.name,
+        domain: abnTest.domain,
+    };
+};
+
+export const joinABNTest = (
+    abnTest: IABNTestReadResponse,
+    deployments: IDeploymentDatum[]
+): IABNTestJoined => {
+    return {
+        id: abnTest?.id,
+        name: abnTest?.name,
+        domain: abnTest?.domain,
+        elements: abnTest?.elements?.map((e) => ({
+            deployment: deployments?.find((d) => d.id === e.deploymentId)!,
+            weight: e.weight,
+        })),
+    };
+};


### PR DESCRIPTION
# ABN 테스트 페이지 개발 및 API 연동


## Tasks

- [x] 기존 AB 테스트 폴더 구조 분리
- [x] ABN 테스트 페이지 개발 및 API 연동 


## Discussion

- 레거시 AB 테스트 관련 백엔드 API 및 페이지를 어떻게 관리할지 고민이 되네요~ 아예 삭제하거나, routes 내부에서 hidden 조치하거나, 그대로 두는 방법 정도가 있을 텐데 어떻게 처리할지 의견 주시면 감사하겠습니다!
- useData에 atom cleanup 핸들러를 추가한 결과로 페이지 전환 사이에 가끔 atom이 잠깐씩 빈 배열이 들어가는 이슈가 있었습니다! 단순히 undefined 핸들링만 해줘서 해결했는데요, 이 결과로 코드가 조금 더러워진것 같긴 하네요 ㅜㅜ
- 코드 리뷰 부탁드립니다~


## Jira

- SO1S-483

## Screenshots
![Screenshot from 2022-11-20 23-50-58](https://user-images.githubusercontent.com/32592965/202953748-b18c17c3-c8fc-4371-8830-4e11880b5ab9.png)
![Screenshot from 2022-11-20 23-50-52](https://user-images.githubusercontent.com/32592965/202953753-91edf1e9-e8fc-43bd-a291-523f6c82bf33.png)
![Screenshot from 2022-11-20 23-49-52](https://user-images.githubusercontent.com/32592965/202953755-c0ecb82e-980d-49e2-8d5c-0a8f12fcdf83.png)
